### PR TITLE
fix: Use the correct gigalixir command to migrate in-band to the deploy.

### DIFF
--- a/actions/gigalixir-deploy/action.yml
+++ b/actions/gigalixir-deploy/action.yml
@@ -33,7 +33,7 @@ runs:
     - run: git push -f gigalixir HEAD:refs/heads/main
       shell: bash
       working-directory: "${{ inputs.working-directory }}"
-    - run: gigalixir run mix ecto.migrate
+    - run: gigalixir ps:migrate
       if: ${{ inputs.run-migrations == 'true' }}
       shell: bash
       working-directory: "${{ inputs.working-directory }}"


### PR DESCRIPTION
This change uses the `ps:migrate` gigalixir command which will run the migrations attached to the current terminal rather than in the background, so any potential migration failures should cause the CI run to fail.