### PR TITLE
improvement: Use the inbuilt functionality of `erlef/setup-beam` to read from .tool-versions

### DIFF
--- a/actions/install-elixir/action.yml
+++ b/actions/install-elixir/action.yml
@@ -1,16 +1,11 @@
 name: Install Elixir and Erlang
 description: "Install Erlang and Elixir as per the `.tool-versions` file."
-inputs:
-  working-directory:
-    description: "Change the working directory that the commands are run within"
-    required: false
-    default: "${{ github.workspace }}"
 runs:
   using: "composite"
   steps:
     - uses: erlef/setup-beam@v1
       with:
-        version-file: "${{ inputs.working-directory }}/.tool-versions"
+        version-file: .tool-versions
         version-type: strict
       env:
         HEX_HOME: ${{ runner.temp }}/.hex

--- a/actions/install-elixir/action.yml
+++ b/actions/install-elixir/action.yml
@@ -8,18 +8,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - id: erlang
-      run: echo "erlang_version=$(grep erlang .tool-versions | cut -d ' ' -f 2)" >> $GITHUB_OUTPUT
-      shell: bash
-      working-directory: "${{ inputs.working-directory }}"
-    - id: elixir
-      run: echo "elixir_version=$(grep elixir .tool-versions | cut -d ' ' -f 2)" >> $GITHUB_OUTPUT
-      shell: bash
-      working-directory: "${{ inputs.working-directory }}"
     - uses: erlef/setup-beam@v1
       with:
-        otp-version: ${{ steps.erlang.outputs.erlang_version }}
-        elixir-version: ${{ steps.elixir.outputs.elixir_version }}
+        version-file: "${{ inputs.working-directory }}/.tool-versions"
+        version-type: strict
       env:
         HEX_HOME: ${{ runner.temp }}/.hex
         MIX_HOME: ${{ runner.temp }}/.mix

--- a/actions/mix-deps-get/action.yml
+++ b/actions/mix-deps-get/action.yml
@@ -22,8 +22,6 @@ runs:
   steps:
     - name: Install Erlang and Elixir
       uses: team-alembic/staple-actions/actions/install-elixir@main
-      with:
-        working-directory: "${{ inputs.working-directory }}"
     - name: Retrieve Mix Dependencies Cache
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
`erlef/setup-beam` now supports reading versions from a .tool-versions file, so we can use that instead of manually parsing it.

https://github.com/erlef/setup-beam/#version-file

In practice it looks like this - 

https://github.com/paulo-ferraz-oliveira/setup-beam-example/blob/main/.github/workflows/ci.yml