### PR TITLE
feat: adds `mix check` github action

### DIFF
--- a/actions/mix-check/action.yml
+++ b/actions/mix-check/action.yml
@@ -1,0 +1,39 @@
+name: mix check
+description: "Runs `mix check`"
+inputs:
+  git-token:
+    required: false
+    default: ${{ github.token }}
+    description: "A Github access token for checking out git-based dependencies."
+  mix-env:
+    description: "The Mix environment to compile within"
+    required: true
+  working-directory:
+    description: "Change the working directory that the commands are run within"
+    required: false
+    default: "${{ github.workspace }}"
+  use-cache:
+    description: "Use caches?"
+    required: false
+    default: "true"
+  cache-prefix:
+    description: "Optional prefix for the cache key"
+    required: false
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - uses: team-alembic/staple-actions/actions/mix-compile@main
+      with:
+        git-token: ${{ inputs.git-token }}
+        working-directory: ${{ inputs.working-directory }}
+        use-cache: ${{ inputs.use-cache }}
+        cache-prefix: ${{ inputs.cache-prefix }}
+        mix-env: ${{ inputs.mix-env }}
+    - run: mix check
+      shell: bash
+      env:
+        MIX_ENV: ${{ inputs.mix-env }}
+        HEX_HOME: ${{ runner.temp }}/.hex
+        MIX_HOME: ${{ runner.temp }}/.mix
+      working-directory: "${{ inputs.working-directory }}"


### PR DESCRIPTION
`mix check` is a mix task made available by the `ex_check` dependency. It has the following optional dependencies:
- credo
- dialyxir
- doctor
- ex_doc
- sobelow
- mix_audit

If the dependences are installed in the project then they will be run as part of `mix check`.

`mix check` behaviour can be customised through `.check.exs`. For more information see the gh repo:
https://github.com/karolsluszniak/ex_check