### PR TITLE
fix: drop OTP-version-agnostic build cache restore-key

### DIFF
--- a/actions/mix-compile-composable/action.yml
+++ b/actions/mix-compile-composable/action.yml
@@ -31,7 +31,6 @@ runs:
         key: ${{ inputs.cache-prefix}}-build-${{ inputs.mix-env }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(format('{0}{1}', inputs.working-directory, '/.tool-versions')) }}-${{ hashFiles(format('{0}{1}', inputs.working-directory, '/mix.lock')) }}
         restore-keys: |
           ${{ inputs.cache-prefix}}-build-${{ inputs.mix-env }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(format('{0}{1}', inputs.working-directory, '/.tool-versions')) }}-
-          ${{ inputs.cache-prefix}}-build-${{ inputs.mix-env }}-${{ runner.os }}-${{ runner.arch }}-
       if: ${{ inputs.use-cache == 'true' }}
     - run: mix compile ${{ inputs.args }}
       shell: bash

--- a/actions/mix-compile/action.yml
+++ b/actions/mix-compile/action.yml
@@ -41,7 +41,6 @@ runs:
         key: ${{ inputs.cache-prefix}}-build-${{ inputs.mix-env }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(format('{0}{1}', inputs.working-directory, '/.tool-versions')) }}-${{ hashFiles(format('{0}{1}', inputs.working-directory, '/mix.lock')) }}
         restore-keys: |
           ${{ inputs.cache-prefix}}-build-${{ inputs.mix-env }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(format('{0}{1}', inputs.working-directory, '/.tool-versions')) }}-
-          ${{ inputs.cache-prefix}}-build-${{ inputs.mix-env }}-${{ runner.os }}-${{ runner.arch }}-
       if: ${{ inputs.use-cache == 'true' }}
     - run: mix compile ${{ inputs.args }}
       shell: bash


### PR DESCRIPTION
## Summary

The build cache in `mix-compile` and `mix-compile-composable` has a `restore-keys` fallback that ignores `.tool-versions`:

```yaml
restore-keys: |
  …-build-${mix-env}-${os}-${arch}-${hashFiles('.tool-versions')}-
  …-build-${mix-env}-${os}-${arch}-     # ← this one
```

After an OTP/Elixir upgrade, `actions/cache` happily restores a `_build/` snapshot whose beam chunk format predates the current toolchain. `mix compile` is incremental and won't rebuild beams it considers fresh, so the OTP-mismatched beams persist into later steps.

Anything that introspects BEAM chunks then breaks. The case that surfaced this was dialyzer:

```
:dialyzer.run error: Analysis failed with error:
Could not get Core Erlang code for: …/Elixir.MyMod.beam
Recompile with +debug_info or analyze starting from source code
```

…even though the same sources compile cleanly with `debug_info` locally. The cache had been silently poisoned for weeks, and only the dialyzer step noticed.

## Change

Drop the most permissive restore-key from both `mix-compile/action.yml` and `mix-compile-composable/action.yml`. The `.tool-versions`-bounded fallback remains, so:

- Incremental builds across `mix.lock` changes still work (the original goal of #15).
- A `.tool-versions` change now correctly invalidates the build cache — no more cross-OTP-version reuse.

`mix-deps-get` keeps its broader `restore-keys` because the `deps/` directory holds source, not beams, so it's not exposed to the same hazard.

## Test plan

- [ ] Manually run a workflow consuming this branch and confirm a fresh cache key is produced on first build.
- [ ] Confirm that a subsequent build with the same `.tool-versions` and unchanged `mix.lock` reuses the cache (exact hit).
- [ ] Confirm that a `.tool-versions` bump (e.g. OTP minor bump) misses the cache cleanly rather than falling back to a stale snapshot.