### PR TITLE
fix: drop broad restore-keys from mix deps cache

### DIFF
--- a/actions/mix-deps-get-composable/action.yml
+++ b/actions/mix-deps-get-composable/action.yml
@@ -25,8 +25,6 @@ runs:
       with:
         path: ${{ inputs.working-directory }}/deps
         key: ${{ inputs.cache-prefix }}-deps-${{ hashFiles(format('{0}{1}', inputs.working-directory, '/mix.lock')) }}
-        restore-keys: |
-          ${{ inputs.cache-prefix }}-deps
       if: ${{ inputs.use-cache == 'true' }}
     - name: Retrieve MIX_HOME Cache
       uses: actions/cache@v3

--- a/actions/mix-deps-get/action.yml
+++ b/actions/mix-deps-get/action.yml
@@ -27,8 +27,6 @@ runs:
       with:
         path: ${{ inputs.working-directory }}/deps
         key: ${{ inputs.cache-prefix }}-deps-${{ hashFiles(format('{0}{1}', inputs.working-directory, '/mix.lock')) }}
-        restore-keys: |
-          ${{ inputs.cache-prefix }}-deps
       if: ${{ inputs.use-cache == 'true' }}
     - name: Retrieve MIX_HOME Cache
       uses: actions/cache@v3


### PR DESCRIPTION
The `deps` cache in `mix-deps-get` and `mix-deps-get-composable` used an exact key (`-deps-<hash(mix.lock)>`) plus a broad `restore-keys: -deps` prefix.

## The bug

On a dependency version bump the exact key misses (mix.lock changed), and the `restore-keys` prefix restores the newest `-deps-*` cache — i.e. some other lock's `deps/`, containing the old version unpacked on disk. `mix deps.get` does not reconcile an already-present wrong-version dep, so `mix compile` aborts with:

```
Unchecked dependencies for environment test:
* bb (Hex package)
  the dependency does not match the requirement "~> 0.20", got "0.18.0"
```

This bit several beam-bots downstream repos whenever they adopted a new upstream release.

## The fix

Make the deps cache **exact-key-only**:

- An exact-key hit always matches `mix.lock` (correct by construction).
- A miss starts from an empty `deps/`, so `mix deps.get` fetches the right versions.

The `HEX_HOME`/`MIX_HOME` tarball caches (content-addressed, safe to share) keep that fetch fast, and the `_build` `restore-keys` in `mix-compile` are left intact for warm incremental compiles — once `deps/` is correct, the dependency check passes and a stale `_build` just triggers a normal recompile.