### PR TITLE
chore: Use the `--exit` flag for sobelow to fail if any violations are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Compile & quality checks:
 - `mix-doctor` / `-composable` — `mix doctor --full --raise`.
 - `mix-check` / `-composable` — `mix check` (runs an aggregated check
   pipeline).
-- `mix-sobelow` / `-composable` — `mix sobelow --config`.
+- `mix-sobelow` / `-composable` — `mix sobelow --config --exit`.
 - `mix-dialyzer` / `-composable` — `mix dialyzer` with PLT caching.
 - `mix-dialyzer-plt` / `-composable` — build only the Dialyzer PLT.
 

--- a/actions/mix-sobelow-composable/action.yml
+++ b/actions/mix-sobelow-composable/action.yml
@@ -1,5 +1,5 @@
 name: mix sobelow --config
-description: "Runs `mix sobelow --config`"
+description: "Runs `mix sobelow --config --exit`"
 inputs:
   mix-env:
     description: "The Mix environment to compile within"
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: mix sobelow --config
+    - run: mix sobelow --config --exit
       shell: bash
       env:
         MIX_ENV: ${{ inputs.mix-env }}

--- a/actions/mix-sobelow/action.yml
+++ b/actions/mix-sobelow/action.yml
@@ -1,5 +1,5 @@
 name: mix sobelow --config
-description: "Runs `mix sobelow --config`"
+description: "Runs `mix sobelow --config --exit`"
 inputs:
   git-token:
     required: false
@@ -30,7 +30,7 @@ runs:
         use-cache: ${{ inputs.use-cache }}
         cache-prefix: ${{ inputs.cache-prefix }}
         mix-env: ${{ inputs.mix-env }}
-    - run: mix sobelow --config
+    - run: mix sobelow --config --exit
       shell: bash
       env:
         MIX_ENV: ${{ inputs.mix-env }}


### PR DESCRIPTION
Without this flag, the exit status is always zero and the check will always pass

(I'm not sure why this isn't the default behaviour...)